### PR TITLE
Add address related fields and foundation

### DIFF
--- a/contexts/citizenship-v1.jsonld
+++ b/contexts/citizenship-v1.jsonld
@@ -21,6 +21,7 @@
 
         "description": "http://schema.org/description",
         "name": "http://schema.org/name",
+        "filingLocation": "https://w3id.org/citizenship#filingLocation",
         "identifier": "http://schema.org/identifier",
         "image": {"@id": "http://schema.org/image", "@type": "@id"}
       }

--- a/contexts/citizenship-v1.jsonld
+++ b/contexts/citizenship-v1.jsonld
@@ -7,6 +7,8 @@
     "description": "http://schema.org/description",
     "identifier": "http://schema.org/identifier",
     "image": {"@id": "http://schema.org/image", "@type": "@id"},
+    "unitCode": "https://schema.org/unitCode",
+    "value": "https://schema.org/value",
 
     "PermanentResidentCard": {
       "@id": "https://w3id.org/citizenship#PermanentResidentCard",
@@ -43,12 +45,15 @@
         "familyName": "schema:familyName",
         "gender": "schema:gender",
         "givenName": "schema:givenName",
+        "height": "https://schema.org/height",
         "lprCategory": "ctzn:lprCategory",
         "lprNumber": "ctzn:lprNumber",
         "residentSince": {"@id": "ctzn:residentSince", "@type": "xsd:dateTime"}
       }
     },
 
-    "Person": "http://schema.org/Person"
+    "Person": "http://schema.org/Person",
+
+    "QuantitativeValue": "https://schema.org/QuantitativeValue"
   }
 }

--- a/contexts/citizenship-v1.jsonld
+++ b/contexts/citizenship-v1.jsonld
@@ -48,11 +48,21 @@
         "height": "https://schema.org/height",
         "lprCategory": "ctzn:lprCategory",
         "lprNumber": "ctzn:lprNumber",
+        "residence": "ctzn:residence",
         "residentSince": {"@id": "ctzn:residentSince", "@type": "xsd:dateTime"}
       }
     },
 
     "Person": "http://schema.org/Person",
+
+    "PostalAddress": {
+      "@id": "https://schema.org/PostalAddress",
+      "@context": {
+        "addressCountry": "https://schema.org/addressCountry",
+        "addressLocality": "https://schema.org/addressLocality",
+        "addressRegion": "https://schema.org/addressRegion"
+      }
+    },
 
     "QuantitativeValue": "https://schema.org/QuantitativeValue"
   }

--- a/index.html
+++ b/index.html
@@ -269,6 +269,15 @@ Person
 Specifies that the subject of the credential is a person.
             </td>
           </tr>
+          <tr>
+            <td>
+QuantitativeValue
+            </td>
+            <td>
+A point value or interval for product characteristics and other purposes. Used
+with `height`.
+            </td>
+          </tr>
         </tbody>
       </table>
 
@@ -336,6 +345,14 @@ The non-family name with which the individual identifies.
           </tr>
           <tr>
             <td>
+height
+            </td>
+            <td>
+The height of the item.
+            </td>
+          </tr>
+          <tr>
+            <td>
 image
             </td>
             <td>
@@ -366,6 +383,24 @@ residentSince
             </td>
             <td>
 The date from which the individual is considered a resident.
+            </td>
+          </tr>
+          <tr>
+            <td>
+unitCode
+            </td>
+            <td>
+The unit of measurement given using the UN/CEFACT Common Code (3 characters) or
+a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix
+followed by a colon. Used with `height`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+value
+            </td>
+            <td>
+The value of a `QuantitativeValue`. Used with `height`.
             </td>
           </tr>
         </tbody>
@@ -594,6 +629,44 @@ string
         </table>
 
       </section>
+      <section class="normative">
+        <h3>height</h3>
+
+        <p>
+The height of the item expressed as a <a>QuantitativeValue</a>.
+        </p>
+
+        <table class="simple">
+          <tbody>
+            <tr>
+              <td>
+Term
+              </td>
+              <td>
+height
+              </td>
+            </tr>
+            <tr>
+              <td>
+URL
+              </td>
+              <td>
+http://schema.org/height
+              </td>
+            </tr>
+            <tr>
+              <td>
+Expected Value
+              </td>
+              <td>
+string
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+
       <section class="normative">
         <h3>identifier</h3>
 
@@ -855,6 +928,43 @@ Class
 
       </section>
       <section class="normative">
+        <h3>QuantitativeValue</h3>
+
+        <p>
+A point value or interval for product characteristics and other purposes.
+        </p>
+
+        <table class="simple">
+          <tbody>
+            <tr>
+              <td>
+Term
+              </td>
+              <td>
+QuantitativeValue
+              </td>
+            </tr>
+            <tr>
+              <td>
+URL
+              </td>
+              <td>
+http://schema.org/QuantitativeValue
+              </td>
+            </tr>
+            <tr>
+              <td>
+Expected Value
+              </td>
+              <td>
+Class
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+      <section class="normative">
         <h3>residentSince</h3>
 
         <p>
@@ -891,6 +1001,85 @@ Datetime
         </table>
 
       </section>
+
+      <section class="normative">
+        <h3>unitCode</h3>
+
+        <p>
+The unit of measurement given using the UN/CEFACT Common Code (3 characters) or
+a URL. Other codes than the UN/CEFACT Common Code may be used with a prefix
+followed by a colon. Used with `height`.
+        </p>
+
+        <table class="simple">
+          <tbody>
+            <tr>
+              <td>
+Term
+              </td>
+              <td>
+unitCode
+              </td>
+            </tr>
+            <tr>
+              <td>
+URL
+              </td>
+              <td>
+https://schema.org/unitCode
+              </td>
+            </tr>
+            <tr>
+              <td>
+Expected Value
+              </td>
+              <td>
+string
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+
+      <section class="normative">
+        <h3>value</h3>
+
+        <p>
+The value of a `QuantitativeValue`. Used with `height`.
+        </p>
+
+        <table class="simple">
+          <tbody>
+            <tr>
+              <td>
+Term
+              </td>
+              <td>
+value
+              </td>
+            </tr>
+            <tr>
+              <td>
+URL
+              </td>
+              <td>
+https://schema.org/unitCode
+              </td>
+            </tr>
+            <tr>
+              <td>
+Expected Value
+              </td>
+              <td>
+Number
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+
     </section>
 
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -215,7 +215,18 @@ is useful:
         "unitCode": "in",
         "value": 11
       }
-    ]
+    ],
+    "residence": {
+      "type": ["PostalAddress"],
+      "addressLocality": "Boston",
+      "addressRegion": "Massachusetts"
+    },
+    "filingLocation": {
+      "type": ["PostalAddress"],
+      "addressLocality": "Washington, D.C.",
+      "addressRegion": "District of Columbia",
+      "addressCountry": "US"
+    }
   },
   "proof": {
      "type": "Ed25519Signature2018",

--- a/index.html
+++ b/index.html
@@ -373,6 +373,14 @@ The name of the family with which the individual identifies.
           </tr>
           <tr>
             <td>
+filingLocation
+            </td>
+            <td>
+The `PostalAddress` where naturalization paperwork was filled.
+            </td>
+          </tr>
+          <tr>
+            <td>
 gender
             </td>
             <td>

--- a/index.html
+++ b/index.html
@@ -204,7 +204,18 @@ is useful:
     "lprNumber": "999-999-999",
     "commuterClassification": "C1",
     "birthCountry": "Bahamas",
-    "birthDate": "1958-07-17"
+    "birthDate": "1958-07-17",
+    "height": [
+      {
+        "type": ["QuantitativeValue"],
+        "unitCode": "ft",
+        "value": 5
+      }, {
+        "type": ["QuantitativeValue"],
+        "unitCode": "in",
+        "value": 11
+      }
+    ]
   },
   "proof": {
      "type": "Ed25519Signature2018",

--- a/index.html
+++ b/index.html
@@ -282,6 +282,15 @@ Specifies that the subject of the credential is a person.
           </tr>
           <tr>
             <td>
+PostalAddress
+            </td>
+            <td>
+A mailing address.
+            </td>
+          </tr>
+
+          <tr>
+            <td>
 QuantitativeValue
             </td>
             <td>
@@ -305,6 +314,30 @@ citizenship status:
           </tr>
         </thead>
         <tbody>
+          <tr>
+            <td>
+addressCountry
+            </td>
+            <td>
+The country code provided as a two-letter ISO 3166-1 alpha-2 country code.
+            </td>
+          </tr>
+          <tr>
+            <td>
+addressLocality
+            </td>
+            <td>
+The locality of within an `addressRegion`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+addressRegion
+            </td>
+            <td>
+The region within an `addressCountry`.
+            </td>
+          </tr>
           <tr>
             <td>
 birthCountry
@@ -390,6 +423,14 @@ country's official body for making such a determination.
           </tr>
           <tr>
             <td>
+residence
+            </td>
+            <td>
+The `PostalAddress` in which the `Person` currently resides.
+            </td>
+          </tr>
+          <tr>
+            <td>
 residentSince
             </td>
             <td>
@@ -417,6 +458,117 @@ The value of a `QuantitativeValue`. Used with `height`.
         </tbody>
       </table>
 
+      <section class="normative">
+        <h3>addressCountry</h3>
+
+        <p>
+The country code provided as a two-letter ISO 3166-1 alpha-2 country code.
+        </p>
+
+        <table class="simple">
+          <tbody>
+            <tr>
+              <td>
+Term
+              </td>
+              <td>
+addressCountry
+              </td>
+            </tr>
+            <tr>
+              <td>
+URL
+              </td>
+              <td>
+http://schema.org/addressCountry
+              </td>
+            </tr>
+            <tr>
+              <td>
+Expected Value
+              </td>
+              <td>
+string
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+      <section class="normative">
+        <h3>addressLocality</h3>
+
+        <p>
+The locality of within an `addressRegion`.
+        </p>
+
+        <table class="simple">
+          <tbody>
+            <tr>
+              <td>
+Term
+              </td>
+              <td>
+addressLocality
+              </td>
+            </tr>
+            <tr>
+              <td>
+URL
+              </td>
+              <td>
+http://schema.org/addressLocality
+              </td>
+            </tr>
+            <tr>
+              <td>
+Expected Value
+              </td>
+              <td>
+string
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+      <section class="normative">
+        <h3>addressRegion</h3>
+
+        <p>
+The region within an `addressCountry`.
+        </p>
+
+        <table class="simple">
+          <tbody>
+            <tr>
+              <td>
+Term
+              </td>
+              <td>
+addressRegion
+              </td>
+            </tr>
+            <tr>
+              <td>
+URL
+              </td>
+              <td>
+http://schema.org/addressRegion
+              </td>
+            </tr>
+            <tr>
+              <td>
+Expected Value
+              </td>
+              <td>
+string
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
       <section class="normative">
         <h3>birthCountry</h3>
 
@@ -938,6 +1090,44 @@ Class
         </table>
 
       </section>
+      <section class="normative">
+        <h3>PostalAddress</h3>
+
+        <p>
+A mailing address.
+        </p>
+
+        <table class="simple">
+          <tbody>
+            <tr>
+              <td>
+Term
+              </td>
+              <td>
+PostalAddress
+              </td>
+            </tr>
+            <tr>
+              <td>
+URL
+              </td>
+              <td>
+http://schema.org/PostalAddress
+              </td>
+            </tr>
+            <tr>
+              <td>
+Expected Value
+              </td>
+              <td>
+Class
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
+
       <section class="normative">
         <h3>QuantitativeValue</h3>
 


### PR DESCRIPTION
This PR adds the [`PostalAddress`](https://schema.org/PostalAddress) type from schema.org and makes use of a few of it's fields for `residence`.

Addresses needs in #15.

NOTE: this is stacked on #16 for my own convenience. I can untangle or combine these if wanted.