### PR TITLE
Update v2 context

### DIFF
--- a/contexts/citizenship-v2.jsonld
+++ b/contexts/citizenship-v2.jsonld
@@ -184,6 +184,24 @@
       }
     },
 
-    "CertificateOfCitizenshipCredential": "https://w3id.org/citizenship#CertificateOfCitizenshipCredential"
+    "CertificateOfCitizenshipCredential": "https://w3id.org/citizenship#CertificateOfCitizenshipCredential",
+    "OpticalBarcodeCredential": "https://w3id.org/citizenship#OpticalBarcodeCredential",
+    "TerseBitstringStatusListEntry": {
+      "@id":
+        "https://w3id.org/citizenship#TerseBitstringStatusListEntry",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "terseStatusListBaseUrl": {
+          "@type": "@id",
+          "@id": "https://w3id.org/citizenship#terseStatusListBaseUrl"
+        },
+        "terseStatusListIndex":
+          "https://w3id.org/citizenship#terseStatusListIndex"
+      }
+    }
   }
 }

--- a/index.html
+++ b/index.html
@@ -510,7 +510,7 @@ Specifies that the credential is an Optical Barcode credential.
           </tr>
           <tr>
             <td>
-<a href="#TerseBitstringStatusListEntry">OpticalBarcodeCredential</a>
+<a href="#TerseBitstringStatusListEntry">TerseBitstringStatusListEntry</a>
             </td>
             <td>
 Specifies that the object is a Terse Bitstring Status List Entry.

--- a/index.html
+++ b/index.html
@@ -500,6 +500,22 @@ Specifies that the object is a Certificate of Citizenship.
 Specifies that the credential is a Certificate of Citizenship credential.
             </td>
           </tr>
+          <tr>
+            <td>
+<a href="#OpticalBarcodeCredential">OpticalBarcodeCredential</a>
+            </td>
+            <td>
+Specifies that the credential is an Optical Barcode credential.
+            </td>
+          </tr>
+          <tr>
+            <td>
+<a href="#TerseBitstringStatusListEntry">OpticalBarcodeCredential</a>
+            </td>
+            <td>
+Specifies that the object is a Terse Bitstring Status List Entry.
+            </td>
+          </tr>
         </tbody>
       </table>
 
@@ -772,6 +788,22 @@ followed by a colon. Used with `height`.
             </td>
             <td>
 The value of a `QuantitativeValue`. Used with `height`.
+            </td>
+          </tr>
+          <tr>
+            <td>
+<a href="#terseStatusListBaseUrl">terseStatusListBaseUrl</a>
+            </td>
+            <td>
+The base URL of a Bitstring Status List.
+            </td>
+          </tr>
+          <tr>
+            <td>
+<a href="#terseStatusListIndex">terseStatusListIndex</a>
+            </td>
+            <td>
+A terse index for use with a Bitstring Status List.
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
This PR does the following in support of the [Verifiable Credential Barcodes](https://digitalbazaar.github.io/vc-barcodes/) work:

- adds OpticalBarcodeCredential, a credential type used for securing data in an optical barcode.
- adds TerseBitstringStatusListEntry, terseStatusListIndex, and terseStatusListBaseUrl, which together provide a space-efficient mechanism to use [Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/) for status on citizenship credentials.
- updates the data model to contain the additions above.